### PR TITLE
Update goauth dep to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/lib.rs"
 
 [dependencies]
 protobuf = "1.0.24"
-smpl_jwt = "0.2"
-goauth = "0.2"
+smpl_jwt = "0.4"
+goauth = "0.6"
 log = "0.3"
 curl = "0.4"
 serde = "0.9"

--- a/src/any.rs
+++ b/src/any.rs
@@ -3,7 +3,7 @@
 
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
@@ -193,8 +193,8 @@ impl ::protobuf::Message for Any {
         ::std::any::TypeId::of::<Any>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/bigtable.rs
+++ b/src/bigtable.rs
@@ -3,7 +3,7 @@
 
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
@@ -274,8 +274,8 @@ impl ::protobuf::Message for ReadRowsRequest {
         ::std::any::TypeId::of::<ReadRowsRequest>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -517,8 +517,8 @@ impl ::protobuf::Message for ReadRowsResponse {
         ::std::any::TypeId::of::<ReadRowsResponse>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1042,8 +1042,8 @@ impl ::protobuf::Message for ReadRowsResponse_CellChunk {
         ::std::any::TypeId::of::<ReadRowsResponse_CellChunk>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1279,8 +1279,8 @@ impl ::protobuf::Message for SampleRowKeysRequest {
         ::std::any::TypeId::of::<SampleRowKeysRequest>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1496,8 +1496,8 @@ impl ::protobuf::Message for SampleRowKeysResponse {
         ::std::any::TypeId::of::<SampleRowKeysResponse>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1772,8 +1772,8 @@ impl ::protobuf::Message for MutateRowRequest {
         ::std::any::TypeId::of::<MutateRowRequest>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1920,8 +1920,8 @@ impl ::protobuf::Message for MutateRowResponse {
         ::std::any::TypeId::of::<MutateRowResponse>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2135,8 +2135,8 @@ impl ::protobuf::Message for MutateRowsRequest {
         ::std::any::TypeId::of::<MutateRowsRequest>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2363,8 +2363,8 @@ impl ::protobuf::Message for MutateRowsRequest_Entry {
         ::std::any::TypeId::of::<MutateRowsRequest_Entry>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2544,8 +2544,8 @@ impl ::protobuf::Message for MutateRowsResponse {
         ::std::any::TypeId::of::<MutateRowsResponse>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2760,8 +2760,8 @@ impl ::protobuf::Message for MutateRowsResponse_Entry {
         ::std::any::TypeId::of::<MutateRowsResponse_Entry>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3122,8 +3122,8 @@ impl ::protobuf::Message for CheckAndMutateRowRequest {
         ::std::any::TypeId::of::<CheckAndMutateRowRequest>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3318,8 +3318,8 @@ impl ::protobuf::Message for CheckAndMutateRowResponse {
         ::std::any::TypeId::of::<CheckAndMutateRowResponse>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3587,8 +3587,8 @@ impl ::protobuf::Message for ReadModifyWriteRowRequest {
         ::std::any::TypeId::of::<ReadModifyWriteRowRequest>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3783,8 +3783,8 @@ impl ::protobuf::Message for ReadModifyWriteRowResponse {
         ::std::any::TypeId::of::<ReadModifyWriteRowResponse>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,7 +3,7 @@
 
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
@@ -185,8 +185,8 @@ impl ::protobuf::Message for Row {
         ::std::any::TypeId::of::<Row>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -413,8 +413,8 @@ impl ::protobuf::Message for Family {
         ::std::any::TypeId::of::<Family>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -641,8 +641,8 @@ impl ::protobuf::Message for Column {
         ::std::any::TypeId::of::<Column>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -900,8 +900,8 @@ impl ::protobuf::Message for Cell {
         ::std::any::TypeId::of::<Cell>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1329,8 +1329,8 @@ impl ::protobuf::Message for RowRange {
         ::std::any::TypeId::of::<RowRange>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1559,8 +1559,8 @@ impl ::protobuf::Message for RowSet {
         ::std::any::TypeId::of::<RowSet>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2028,8 +2028,8 @@ impl ::protobuf::Message for ColumnRange {
         ::std::any::TypeId::of::<ColumnRange>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2258,8 +2258,8 @@ impl ::protobuf::Message for TimestampRange {
         ::std::any::TypeId::of::<TimestampRange>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2681,8 +2681,8 @@ impl ::protobuf::Message for ValueRange {
         ::std::any::TypeId::of::<ValueRange>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3865,8 +3865,8 @@ impl ::protobuf::Message for RowFilter {
         ::std::any::TypeId::of::<RowFilter>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4148,8 +4148,8 @@ impl ::protobuf::Message for RowFilter_Chain {
         ::std::any::TypeId::of::<RowFilter_Chain>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4322,8 +4322,8 @@ impl ::protobuf::Message for RowFilter_Interleave {
         ::std::any::TypeId::of::<RowFilter_Interleave>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -4598,8 +4598,8 @@ impl ::protobuf::Message for RowFilter_Condition {
         ::std::any::TypeId::of::<RowFilter_Condition>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5026,8 +5026,8 @@ impl ::protobuf::Message for Mutation {
         ::std::any::TypeId::of::<Mutation>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5355,8 +5355,8 @@ impl ::protobuf::Message for Mutation_SetCell {
         ::std::any::TypeId::of::<Mutation_SetCell>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5653,8 +5653,8 @@ impl ::protobuf::Message for Mutation_DeleteFromColumn {
         ::std::any::TypeId::of::<Mutation_DeleteFromColumn>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5850,8 +5850,8 @@ impl ::protobuf::Message for Mutation_DeleteFromFamily {
         ::std::any::TypeId::of::<Mutation_DeleteFromFamily>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -5985,8 +5985,8 @@ impl ::protobuf::Message for Mutation_DeleteFromRow {
         ::std::any::TypeId::of::<Mutation_DeleteFromRow>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -6324,8 +6324,8 @@ impl ::protobuf::Message for ReadModifyWriteRule {
         ::std::any::TypeId::of::<ReadModifyWriteRule>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
-use std;
-use goauth::error::GOErr as go_err;
 use curl::Error as curl_err;
-use serde_json::Error as serde_err;
+use goauth::error::GOErr as go_err;
 use protobuf::error::ProtobufError as pb_err;
+use serde_json::Error as serde_err;
 use smpl_jwt::error::JwtErr as jwt_err;
+use std;
 use std::str::Utf8Error as utf8_err;
 
 macro_rules! impl_from {
@@ -13,7 +13,7 @@ macro_rules! impl_from {
                 BTErr::$enum_ty(e)
             }
         }
-    }
+    };
 }
 
 #[derive(Debug)]
@@ -24,7 +24,7 @@ pub enum BTErr {
     PBErr(pb_err),
     JWTErr(jwt_err),
     UTF8Err(utf8_err),
-    Unknown
+    Unknown,
 }
 
 impl_from!(go_err, GOErr);
@@ -33,7 +33,6 @@ impl_from!(serde_err, SerdeErr);
 impl_from!(pb_err, PBErr);
 impl_from!(jwt_err, JWTErr);
 impl_from!(utf8_err, UTF8Err);
-
 
 impl std::fmt::Display for BTErr {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -50,15 +49,15 @@ impl std::fmt::Display for BTErr {
 }
 
 impl std::error::Error for BTErr {
-  fn description(&self) -> &str {
-    match *self {
-        BTErr::GOErr(ref e) => e.description(),
-        BTErr::CurlErr(ref e) => e.description(),
-        BTErr::SerdeErr(ref e) => e.description(),
-        BTErr::PBErr(ref e) => e.description(),
-        BTErr::JWTErr(ref e) => e.description(),
-        BTErr::UTF8Err(ref e) => e.description(),
-        BTErr::Unknown => "unknown error",
+    fn description(&self) -> &str {
+        match *self {
+            BTErr::GOErr(ref e) => e.description(),
+            BTErr::CurlErr(ref e) => e.description(),
+            BTErr::SerdeErr(ref e) => e.description(),
+            BTErr::PBErr(ref e) => e.description(),
+            BTErr::JWTErr(ref e) => e.description(),
+            BTErr::UTF8Err(ref e) => e.description(),
+            BTErr::Unknown => "unknown error",
+        }
     }
-  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![allow(deprecated)]
 #![allow(dead_code)]
 
-extern crate protobuf_json;
 extern crate goauth;
+extern crate protobuf_json;
 extern crate smpl_jwt;
 #[macro_use]
 extern crate log;
@@ -11,13 +11,13 @@ extern crate protobuf;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 extern crate rustc_serialize;
+extern crate serde_json;
 
 pub mod error;
 pub mod method;
-pub mod support;
 pub mod request;
+pub mod support;
 pub mod utils;
 pub mod wraps;
 

--- a/src/method.rs
+++ b/src/method.rs
@@ -1,5 +1,5 @@
-use protobuf::Message;
 use bigtable::*;
+use protobuf::Message;
 
 pub trait BigTable {
     type M: Message;
@@ -16,7 +16,7 @@ macro_rules! method {
         pub struct $name {
             pub payload: $proto,
             pub url_method: String,
-            pub is_post: bool
+            pub is_post: bool,
         }
 
         impl $name {
@@ -32,9 +32,11 @@ macro_rules! method {
                 let first = x.next().unwrap().to_lowercase().next().unwrap();
                 let rest = x.as_str();
 
-                $name { payload: Default::default(),
-                        url_method: format!(":{}{}", first, rest),
-                        is_post: $post}
+                $name {
+                    payload: Default::default(),
+                    url_method: format!(":{}{}", first, rest),
+                    is_post: $post,
+                }
             }
         }
 
@@ -61,7 +63,6 @@ macro_rules! method {
                 self.is_post
             }
         }
-
     };
 }
 
@@ -94,7 +95,6 @@ macro_rules! method {
 /// ```
 fn read_rows_doctest() {}
 method!(ReadRows, ReadRowsRequest, true);
-
 
 /// ### `SampleRowKeys`
 ///

--- a/src/request.rs
+++ b/src/request.rs
@@ -31,14 +31,14 @@ impl<'a, T: BigTable> BTRequest<'a, T> {
             Some(x) => x,
             None => "https://bigtable.googleapis.com/v2",
         };
-        Ok(String::from(format!(
+        Ok(format!(
             "{}/projects/{}/instances/{}/tables/{}{}",
             base,
             self.table.instance.project.name,
             self.table.instance.name,
             self.table.name,
             self.method.url_method()
-        )))
+        ))
     }
 
     pub fn execute(&self, token: &Token) -> Result<Value, BTErr> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,18 +1,18 @@
-use support::Table;
-use error::BTErr;
 use curl::easy::{Easy, List};
-use method::{BigTable, ReadRows};
-use std;
+use error::BTErr;
 use goauth::auth::Token;
+use method::{BigTable, ReadRows};
+use protobuf_json;
 use serde_json;
 use serde_json::Value;
+use std;
 use std::io::Read;
-use protobuf_json;
+use support::Table;
 
 pub struct BTRequest<'a, T: BigTable> {
     pub base: Option<&'a str>,
     pub table: Table,
-    pub method: T
+    pub method: T,
 }
 
 impl<'a> Default for BTRequest<'a, ReadRows> {
@@ -20,7 +20,7 @@ impl<'a> Default for BTRequest<'a, ReadRows> {
         BTRequest {
             base: None,
             table: Default::default(),
-            method: ReadRows::new()
+            method: ReadRows::new(),
         }
     }
 }
@@ -29,19 +29,19 @@ impl<'a, T: BigTable> BTRequest<'a, T> {
     pub fn form_url(&self) -> Result<String, BTErr> {
         let base = match self.base {
             Some(x) => x,
-            None => "https://bigtable.googleapis.com/v2"
+            None => "https://bigtable.googleapis.com/v2",
         };
-        Ok(String::from(format!("{}/projects/{}/instances/{}/tables/{}{}",
-                             base,
-                             self.table.instance.project.name,
-                             self.table.instance.name,
-                             self.table.name,
-                             self.method.url_method()
-                    )
-        ))
+        Ok(String::from(format!(
+            "{}/projects/{}/instances/{}/tables/{}{}",
+            base,
+            self.table.instance.project.name,
+            self.table.instance.name,
+            self.table.name,
+            self.method.url_method()
+        )))
     }
 
-    pub fn execute(&self, token: &Token) -> Result<Value, BTErr>{
+    pub fn execute(&self, token: &Token) -> Result<Value, BTErr> {
         let mut response_data: Vec<u8> = Vec::new();
         let mut easy = Easy::new();
 
@@ -60,9 +60,7 @@ impl<'a, T: BigTable> BTRequest<'a, T> {
 
         {
             let mut transfer = easy.transfer();
-            transfer.read_function(|buf| {
-                Ok(b_payload.read(buf).unwrap_or(0))
-            })?;
+            transfer.read_function(|buf| Ok(b_payload.read(buf).unwrap_or(0)))?;
             transfer.write_function(|response| {
                 response_data.extend_from_slice(response);
                 Ok(response.len())
@@ -85,7 +83,11 @@ impl<'a, T: BigTable> BTRequest<'a, T> {
 
 fn gen_headers(token: &Token) -> Result<List, BTErr> {
     let mut list = List::new();
-    let auth = format!("Authorization: {} {}", token.token_type(), token.access_token());
+    let auth = format!(
+        "Authorization: {} {}",
+        token.token_type(),
+        token.access_token()
+    );
     list.append(&auth)?;
     list.append("Content-Type: application/json")?;
     Ok(list)

--- a/src/status.rs
+++ b/src/status.rs
@@ -3,7 +3,7 @@
 
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
@@ -219,8 +219,8 @@ impl ::protobuf::Message for Status {
         ::std::any::TypeId::of::<Status>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,34 +1,42 @@
 #[derive(Clone)]
 pub struct Project {
-    pub name: String
+    pub name: String,
 }
 
 impl Default for Project {
     fn default() -> Self {
-        Project { name: String::from("rustbigtable") }
+        Project {
+            name: String::from("rustbigtable"),
+        }
     }
 }
 
 #[derive(Clone)]
 pub struct Instance {
     pub project: Project,
-    pub name: String
+    pub name: String,
 }
 
 impl Default for Instance {
     fn default() -> Self {
-        Instance { name: String::from("test-inst"), project: Default::default() }
+        Instance {
+            name: String::from("test-inst"),
+            project: Default::default(),
+        }
     }
 }
 
 #[derive(Clone)]
 pub struct Table {
     pub instance: Instance,
-    pub name: String
+    pub name: String,
 }
 
 impl Default for Table {
     fn default() -> Self {
-        Table { name: String::from("my-table"), instance: Default::default() }
+        Table {
+            name: String::from("my-table"),
+            instance: Default::default(),
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,11 @@
 use rustc_serialize::base64::{ToBase64, STANDARD};
 
 use goauth::auth::{JwtClaims, Token};
-use goauth::scopes::Scope;
-use goauth::get_token_with_creds;
 use goauth::credentials::Credentials;
+use goauth::get_token_with_creds;
+use goauth::scopes::Scope;
 use smpl_jwt::Jwt;
+use std::str::FromStr;
 
 use error::BTErr;
 
@@ -21,10 +22,13 @@ pub fn get_auth_token(c: &str, fp: bool) -> Result<Token, BTErr> {
         Credentials::from_str(c)?
     };
 
-    let claims = JwtClaims::new(credentials.iss(),
-                             Scope::CloudPlatform,
-                             credentials.token_uri(),
-                             None, Some(60));
+    let claims = JwtClaims::new(
+        credentials.iss(),
+        &Scope::CloudPlatform,
+        credentials.token_uri(),
+        None,
+        Some(60),
+    );
     let jwt = Jwt::new(claims, credentials.rsa_key()?, None);
     Ok(get_token_with_creds(&jwt, &credentials)?)
 }
@@ -33,5 +37,4 @@ pub fn row_key_from_str(str: &str) -> Vec<u8> {
     let mut row_key = Vec::new();
     row_key.extend_from_slice(str.as_bytes());
     row_key
-
 }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -3,7 +3,7 @@
 
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
@@ -133,8 +133,8 @@ impl ::protobuf::Message for DoubleValue {
         ::std::any::TypeId::of::<DoubleValue>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -303,8 +303,8 @@ impl ::protobuf::Message for FloatValue {
         ::std::any::TypeId::of::<FloatValue>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -473,8 +473,8 @@ impl ::protobuf::Message for Int64Value {
         ::std::any::TypeId::of::<Int64Value>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -643,8 +643,8 @@ impl ::protobuf::Message for UInt64Value {
         ::std::any::TypeId::of::<UInt64Value>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -813,8 +813,8 @@ impl ::protobuf::Message for Int32Value {
         ::std::any::TypeId::of::<Int32Value>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -983,8 +983,8 @@ impl ::protobuf::Message for UInt32Value {
         ::std::any::TypeId::of::<UInt32Value>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1153,8 +1153,8 @@ impl ::protobuf::Message for BoolValue {
         ::std::any::TypeId::of::<BoolValue>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1336,8 +1336,8 @@ impl ::protobuf::Message for StringValue {
         ::std::any::TypeId::of::<StringValue>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1519,8 +1519,8 @@ impl ::protobuf::Message for BytesValue {
         ::std::any::TypeId::of::<BytesValue>()
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/wraps.rs
+++ b/src/wraps.rs
@@ -1,19 +1,18 @@
-use serde_json;
+use bigtable::MutateRowsRequest_Entry;
+use data::{Mutation, Mutation_SetCell, ReadModifyWriteRule};
+use error::BTErr;
+use goauth::auth::Token;
+use method::{BigTable, MutateRows, ReadModifyWriteRow, ReadRows, SampleRowKeys};
 use protobuf::RepeatedField;
 use request::BTRequest;
-use data::{ReadModifyWriteRule, Mutation, Mutation_SetCell};
-use bigtable::MutateRowsRequest_Entry;
-use utils::*;
-use method::{BigTable, ReadRows, ReadModifyWriteRow, MutateRows, SampleRowKeys};
-use error::BTErr;
+use serde_json;
 use support::Table;
-use goauth::auth::Token;
-
+use utils::*;
 
 pub fn get_row_prefix(prefix: Option<&str>) -> String {
     match prefix {
         Some(x) => String::from(x),
-        None => String::from("r")
+        None => String::from("r"),
     }
 }
 
@@ -22,7 +21,7 @@ pub struct Row {
     pub row_key: String,
     pub family: String,
     pub qualifier: String,
-    pub value: String
+    pub value: String,
 }
 
 impl Default for Row {
@@ -35,7 +34,6 @@ impl Default for Row {
         }
     }
 }
-
 
 /// ```
 /// extern crate bigtable as bt;
@@ -58,14 +56,11 @@ impl Default for Row {
 /// # }
 /// }
 /// ```
-pub fn bulk_write_rows(rows: &mut Vec<Row>,
-                       token: &Token,
-                       table: Table) -> Result<String, BTErr> {
-
+pub fn bulk_write_rows(rows: &mut Vec<Row>, token: &Token, table: Table) -> Result<String, BTErr> {
     let mut req = BTRequest {
         base: None,
         table,
-        method: MutateRows::new()
+        method: MutateRows::new(),
     };
 
     let mut mutate_entries = Vec::new();
@@ -85,7 +80,9 @@ pub fn bulk_write_rows(rows: &mut Vec<Row>,
         mutate_entries.push(mutate_entry);
     }
 
-    req.method.payload_mut().set_entries(RepeatedField::from_vec(mutate_entries));
+    req.method
+        .payload_mut()
+        .set_entries(RepeatedField::from_vec(mutate_entries));
 
     let response = req.execute(token)?;
     Ok(serde_json::to_string(&response)?)
@@ -112,17 +109,14 @@ pub fn bulk_write_rows(rows: &mut Vec<Row>,
 /// # }
 /// }
 /// ```
-pub fn write_rows(rows: &mut Vec<Row>,
-                  token: &Token,
-                  table: &Table) -> Result<usize, BTErr> {
+pub fn write_rows(rows: &mut Vec<Row>, token: &Token, table: &Table) -> Result<usize, BTErr> {
     let mut total = 0;
 
     for row in rows.drain(..) {
-
         let mut req = BTRequest {
             base: None,
             table: table.clone(),
-            method: ReadModifyWriteRow::new()
+            method: ReadModifyWriteRow::new(),
         };
 
         let mut rules: Vec<ReadModifyWriteRule> = Vec::new();
@@ -131,8 +125,12 @@ pub fn write_rows(rows: &mut Vec<Row>,
 
         rules.push(rule);
 
-        req.method.payload_mut().set_row_key(encode_str(&row.row_key));
-        req.method.payload_mut().set_rules(RepeatedField::from_vec(rules));
+        req.method
+            .payload_mut()
+            .set_row_key(encode_str(&row.row_key));
+        req.method
+            .payload_mut()
+            .set_rules(RepeatedField::from_vec(rules));
 
         let _ = req.execute(token)?;
         total += 1;
@@ -160,13 +158,15 @@ pub fn write_rows(rows: &mut Vec<Row>,
 /// # }
 /// }
 /// ```
-pub fn read_rows(table: &Table,
-                 token: &Token,
-                 rows_limit: Option<i64>) -> Result<serde_json::Value, BTErr> {
+pub fn read_rows(
+    table: &Table,
+    token: &Token,
+    rows_limit: Option<i64>,
+) -> Result<serde_json::Value, BTErr> {
     let mut req = BTRequest {
         base: None,
         table: table.clone(),
-        method: ReadRows::new()
+        method: ReadRows::new(),
     };
 
     if let Some(x) = rows_limit {
@@ -177,8 +177,11 @@ pub fn read_rows(table: &Table,
     Ok(response)
 }
 
-fn make_setcell_mutation(column_qualifier: &str, column_family: &str, blob: Vec<u8>)
-                         -> Mutation_SetCell {
+fn make_setcell_mutation(
+    column_qualifier: &str,
+    column_family: &str,
+    blob: Vec<u8>,
+) -> Mutation_SetCell {
     let mut set_cell = Mutation_SetCell::new();
     set_cell.set_column_qualifier(encode_str(column_qualifier));
     set_cell.set_family_name(String::from(column_family));
@@ -187,8 +190,11 @@ fn make_setcell_mutation(column_qualifier: &str, column_family: &str, blob: Vec<
     set_cell
 }
 
-fn make_readmodifywrite_rule(column_qualifier: &str, column_familiy: &str, blob: Vec<u8>)
-                             -> ReadModifyWriteRule {
+fn make_readmodifywrite_rule(
+    column_qualifier: &str,
+    column_familiy: &str,
+    blob: Vec<u8>,
+) -> ReadModifyWriteRule {
     let mut rule = ReadModifyWriteRule::new();
     rule.set_family_name(String::from(column_familiy));
     rule.set_column_qualifier(encode_str(column_qualifier));
@@ -200,7 +206,7 @@ fn sample_row_keys(token: &Token) -> Result<String, BTErr> {
     let req = BTRequest {
         base: None,
         table: Default::default(),
-        method: SampleRowKeys::new()
+        method: SampleRowKeys::new(),
     };
     let response = req.execute(token)?;
     Ok(serde_json::to_string(&response)?)


### PR DESCRIPTION
Hello! I am forking this repo to prototype a rust application that will persist data in Google Bigtable. This update makes the library compilable in rust v1.39. I updated `goauth` version to `0.6`, which requires `smpl_jwt` to be at version `0.4`. There are some minimal interfaces changes accompanying the dependency updates. 

The second and third commits update code formatting and remove clippy errors. However I am not 100% sure if they are relevant to this repo since the files have 
```
// This file is generated. Do not edit
// @generated
```
headings.